### PR TITLE
Add pxytension lib requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 Flask
 Jinja2
+pyxtension==1.0


### PR DESCRIPTION
I'm just adding pyextension to requirements.txt as it won't work without it :)

`Traceback (most recent call last):
  File "bridge.py", line 11, in <module>
    from pyxtension.Json import Json
ImportError: No module named pyxtension.Json`